### PR TITLE
Add `--now` to first attach

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -154,7 +154,7 @@ jobs:
           fi
 
           if (( n == 1 )); then
-            sudo portablectl attach --profile=trusted --enable "./${images[0]}" && exit 0 || {
+            sudo portablectl attach --profile=trusted --enable --now "./${images[0]}" && exit 0 || {
               echo "### ERROR: Failed to attach image" >&2 ; exit 10
             }
           fi


### PR DESCRIPTION
Adding `--now` to make the portable service start on first deploy.